### PR TITLE
Fix typings for use inside node.js

### DIFF
--- a/es6-promise-pool.d.ts
+++ b/es6-promise-pool.d.ts
@@ -15,4 +15,7 @@ declare class PromisePool<A> extends EventTarget {
   start(): PromiseLike<A>
 }
 
-export default PromisePool
+declare module PromisePool {
+}
+
+export = PromisePool;


### PR DESCRIPTION
With the current typings, you must write your import as 

    import PromisePool from 'es6-promise-pool';

however, this causes a runtime error in Node.js: 

    TypeError: es6_promise_pool_1.default is not a constructor

This commit changes the supported TypeScript import syntax to 

    import * as PromisePool from 'es6-promise-pool';

which works correctly in Node.js