### PR TITLE
Change TS return types from PromiseLike to Promise

### DIFF
--- a/es6-promise-pool.d.ts
+++ b/es6-promise-pool.d.ts
@@ -11,8 +11,8 @@ declare class PromisePool<A> extends EventTarget {
   concurrency(concurrency: number): number
   size(): number
   active(): boolean
-  promise(): PromiseLike<A>
-  start(): PromiseLike<A>
+  promise(): Promise<A>
+  start(): Promise<A>
 }
 
 export default PromisePool


### PR DESCRIPTION
`start()` and `promise()` return a real Promise, which has `then` and `catch`.

According to the [TS docs](https://github.com/Microsoft/TypeScript/blob/696b0f8d43524f743048a6c5d5944939e8b43b99/lib/lib.es5.d.ts#L1291-L1319), `PromiseLike` only has `then` but not `catch`, so it's helpful to give the extra information here about the return type, so people know they can use `catch` on the result as well.

