### PR TITLE
Add typings that work with current TS version

### DIFF
--- a/es6-promise-pool.d.ts
+++ b/es6-promise-pool.d.ts
@@ -1,18 +1,24 @@
-interface Options<A> {
-  promise?: PromiseLike<A>
-}
+// fix 2018-01-08
+
+export = PromisePool
 
 declare class PromisePool<A> extends EventTarget {
-  constructor(
-    source: () => PromiseLike<A>|void,
-    concurrency: number,
-    options?: Options<A>
-  )
-  concurrency(concurrency: number): number
-  size(): number
-  active(): boolean
-  promise(): PromiseLike<A>
-  start(): PromiseLike<A>
+    // skip GeneratorFunction as that is documented to be deprecated starting v3
+    constructor(
+        source: IterableIterator<Promise<A>> | Promise<A> | (() => (Promise<A> | void)) | A,
+        concurrency: number,
+        options?: PromisePool.Options<A>
+    )
+
+    concurrency(concurrency: number): number
+    size(): number
+    active(): boolean
+    promise(): PromiseLike<A>
+    start(): PromiseLike<A>
 }
 
-export default PromisePool
+declare namespace PromisePool {
+    export interface Options<A> {
+        promise?: Promise<A>
+    }
+}


### PR DESCRIPTION
This branch basically just copies the typings from https://github.com/timdp/es6-promise-pool/issues/47 and adds them. Works better than the current typings. 